### PR TITLE
Allow specification of HTTP prefix for an app.

### DIFF
--- a/config/haproxy_template.cfg
+++ b/config/haproxy_template.cfg
@@ -45,7 +45,7 @@ frontend http-in
         {{ else }}
 
         # This is the default proxy criteria
-        acl {{ $app.EscapedId }}-aclrule path_beg -i {{ $app.Id }}
+        acl {{ $app.EscapedId }}-aclrule path_beg -i {{if $app.Env.HTTP_PREFIX }} {{ $app.Env.HTTP_PREFIX  }} {{ else }} {{ $app.Id }} {{ end }}
         use_backend {{ $app.EscapedId }}-cluster if {{ $app.EscapedId }}-aclrule
         {{ end }} {{ end }}
 


### PR DESCRIPTION
Solution for #1.

If HTTP_PREFIX is specified in the Marathon application's environment
variable, it's value will be used as the path prefix used by Haproxy for
routung HTTP requests to the app.

@ankanm can you check and verify ? I don't have a running cluster handy.
