### PR TITLE
Ankan/go version fix

### DIFF
--- a/Dockerfile-deb
+++ b/Dockerfile-deb
@@ -4,14 +4,19 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV GOPATH /opt/go
 
 RUN apt-get update -yqq
-RUN apt-get install -yqq software-properties-common curl git mercurial ruby-dev gcc make
-RUN add-apt-repository -y ppa:ethereum/ethereum && apt-get update && apt-get -y install golang
+RUN apt-get install -yqq software-properties-common curl git mercurial ruby-dev gcc make wget
 RUN gem install fpm
+RUN wget https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz
+RUN tar -C /usr/local -xzf go1.6.2.linux-amd64.tar.gz
+
+ENV PATH /usr/local/go/bin:$PATH
 
 ADD . /opt/go/src/github.com/seomoz/roger-bamboo
 
 WORKDIR /opt/go/src/github.com/seomoz/roger-bamboo
-RUN go get github.com/tools/godep && \
+
+RUN RUN go version && \
+    go get github.com/tools/godep && \
     go get -t github.com/smartystreets/goconvey && \
     cp -r Godeps/_workspace/src/* /opt/go/src/ && \
     /opt/go/bin/godep go build

--- a/Dockerfile-deb
+++ b/Dockerfile-deb
@@ -15,7 +15,7 @@ ADD . /opt/go/src/github.com/seomoz/roger-bamboo
 
 WORKDIR /opt/go/src/github.com/seomoz/roger-bamboo
 
-RUN RUN go version && \
+RUN go version && \
     go get github.com/tools/godep && \
     go get -t github.com/smartystreets/goconvey && \
     cp -r Godeps/_workspace/src/* /opt/go/src/ && \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![bamboo-logo](https://cloud.githubusercontent.com/assets/37033/4110258/a8cc58bc-31ef-11e4-87c9-dd20bd2468c2.png)
 
-roger-bamboo is a service discovey and distributed load balancing
+roger-bamboo is a service discovery and distributed load balancing
 system for Roger, Moz's ClusterOS. It is based on
 [Bamboo](https://github.com/QubitProducts/bamboo). Roger-bamboo adds
 several features to Bamboo including, flexible TCP and HTTP port


### PR DESCRIPTION
It turns out (at least looks so for now) that the odd intermittent haproxy 503s were because of a bug in go 1.5 wherein exec would sometimes create processes with blocked signals - https://github.com/golang/go/issues/13164. The old binary was built with 1.4 and didn’t have this problem.
