### PR TITLE
Added acl set and backend map to template data and utility functions

### DIFF
--- a/services/haproxy/haproxy.go
+++ b/services/haproxy/haproxy.go
@@ -11,12 +11,16 @@ import (
 type TemplateData struct {
 	Apps     marathon.AppList
 	Services map[string]service.Service
+	Acls map[string]bool
+	BackendRules map[string]string
 }
 
 func GetTemplateData(config *conf.Configuration, conn *zk.Conn) TemplateData {
 
 	apps, _ := marathon.FetchApps(config.Marathon)
 	services, _ := service.All(conn, config.Bamboo.Zookeeper)
+	acls := make(map[string]bool)
+	backendrules := make(map[string]string)
 
-	return TemplateData{apps, services}
+	return TemplateData{apps, services, acls, backendrules}
 }

--- a/services/template/template.go
+++ b/services/template/template.go
@@ -78,6 +78,7 @@ func getServerHash(escapeId string, host string, port int) string {
 	return fmt.Sprintf("%X", hash)
 }
 
+/* Compute a hash for the given 2 strings */
 func getVersionHash(appId string, version string) string {
 	hasher.Write([]byte(appId))
 	hasher.Write([]byte(version))

--- a/services/template/template.go
+++ b/services/template/template.go
@@ -87,7 +87,7 @@ func getVersionHash(appId string, version string) string {
 	return fmt.Sprintf("%X", hash)
 }
 
-/* Replaces "/" with "::"*/
+/* Replaces "/" with "::" */
 func escapeSlashes(someString string) string {
 	return strings.Replace(someString, "/", "::", -1)
 }

--- a/services/template/template.go
+++ b/services/template/template.go
@@ -19,6 +19,7 @@ import (
 var taskPortRegex = regexp.MustCompile("^PORT([\\d]+)$")
 var numPortRegex = regexp.MustCompile("^[\\d]+$")
 var hasher = fnv.New32a()
+var hasher64 = fnv.New64a()
 
 func hasKey(data map[string]service.Service, appId string) bool {
 	_, exists := data[appId]
@@ -78,12 +79,11 @@ func getServerHash(escapeId string, host string, port int) string {
 	return fmt.Sprintf("%X", hash)
 }
 
-/* Compute a hash for the given 2 strings */
-func getVersionHash(appId string, version string) string {
-	hasher.Write([]byte(appId))
-	hasher.Write([]byte(version))
-	hash := hasher.Sum32()
-	hasher.Reset()
+/* Compute a hash for the given string */
+func getHash(str string) string {
+	hasher64.Write([]byte(str))
+	hash := hasher64.Sum64()
+	hasher64.Reset()
 	return fmt.Sprintf("%X", hash)
 }
 
@@ -120,7 +120,7 @@ func getConditionsDescending(backendrules map[string]string) []string {
 	Returns string content of a rendered template
 */
 func RenderTemplate(templateName string, templateContent string, data interface{}) (string, error) {
-	funcMap := template.FuncMap{"hasKey": hasKey, "getService": getService, "getTime": getTime, "getTaskPort": getTaskPort, "getServerHash": getServerHash, "getVersionHash": getVersionHash, "escapeSlashes": escapeSlashes, "addAcl": addAcl, "addBackendRule": addBackendRule, "getConditionsDescending": getConditionsDescending }
+	funcMap := template.FuncMap{"hasKey": hasKey, "getService": getService, "getTime": getTime, "getTaskPort": getTaskPort, "getServerHash": getServerHash, "getHash": getHash, "escapeSlashes": escapeSlashes, "addAcl": addAcl, "addBackendRule": addBackendRule, "getConditionsDescending": getConditionsDescending }
 
 	tpl := template.Must(template.New(templateName).Funcs(funcMap).Parse(templateContent))
 


### PR DESCRIPTION
- Allows the ability to store and prioritize acls and backend rules to better handle them.
- Examples:
  - Provide the ability to differentiate between `/path1` and `/path1/path2` irrespective of order of deployment because in descending oder `/path1/path2` will come before `/path1` (if `/path1` ends up first, requests for `/path1/path2` also goes to `/path1` which is undesirable.
  - Provide the ability to deploy multiple apps (say different versions) on the same path (acl) and make it possible to have the last deploy take precedence over older ones for new clients (if required, session affinity and version affinity can allow existing clients to still talk to older ones.)
